### PR TITLE
Update the gem name and information

### DIFF
--- a/klarna.gemspec
+++ b/klarna.gemspec
@@ -5,13 +5,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'klarna/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'klarna_client'
+  spec.name          = 'klarna_proxy'
   spec.version       = Klarna::VERSION
-  spec.authors       = ['Jose Antonio Pio Gil', 'Pascal Jungblut']
-  spec.email         = ['jose.pio@bitspire.de', 'pascal.jungblut@bitspire.de']
+  spec.authors       = ['Andrea Vassallo']
+  spec.email         = ['andrea.vassallo.94@gmail.com']
 
-  spec.summary       = 'Klarna Ruby Client'
-  spec.description   = 'Provides a Ruby interface to the current Klarna API'
+  spec.summary       = 'Klarna Ruby Proxy'
+  spec.description   = 'Provides a Ruby interface to the current Klarna API, forked and inspired by https://rubygems.org/gems/klarna_client/versions/0.1.0'
   spec.homepage      = ''
   spec.license       = 'Apache-2.0'
 

--- a/lib/klarna/version.rb
+++ b/lib/klarna/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Klarna
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end


### PR DESCRIPTION
This is needed since this gem was forked from an existing project that is now unmaintained.
We want to publish that gem on rubygems and to do that we have to change the gem name and information.